### PR TITLE
Optimize LearningEngine similarity retrieval path

### DIFF
--- a/ai/learning/learning_engine.py
+++ b/ai/learning/learning_engine.py
@@ -109,6 +109,8 @@ class LearningEngine:
 
         self._tfidf_matrix = None
         self._needs_refit = True
+        self._similarity_cache: Dict[Tuple[str, int], List[TrainingExample]] = {}
+        self._similarity_cache_max_entries = 256
 
         # Storage
         self.training_file = self.data_dir / "training_data.jsonl"
@@ -196,6 +198,7 @@ class LearningEngine:
 
             # Mark TF-IDF matrix as needing refit after new example
             self._needs_refit = True
+            self._similarity_cache.clear()
 
     def run_offline_training(self, max_entries: int = 500) -> Dict[str, Any]:
         """
@@ -320,6 +323,7 @@ class LearningEngine:
         texts = [ex.user_input for ex in self.examples]
         self._tfidf_matrix = self.vectorizer.fit_transform(texts)
         self._needs_refit = False
+        self._similarity_cache.clear()
 
     def _learn_pattern(self, example: TrainingExample):
         """Learn a single pattern"""
@@ -344,8 +348,15 @@ class LearningEngine:
             return []
         if len(self.examples) < 2:
             return []
+        if top_k <= 0:
+            return []
 
         try:
+            cache_key = (user_input, top_k)
+            cached = self._similarity_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
             # Refit the shared vectorizer only when examples have changed
             if self._needs_refit:
                 self._refit_vectorizer()
@@ -353,13 +364,18 @@ class LearningEngine:
             # Transform only the query using the already-fitted vectorizer
             query_vec = self.vectorizer.transform([user_input])
             similarities = cosine_similarity(query_vec, self._tfidf_matrix)[0]
-            top_indices = np.argsort(similarities)[::-1][:top_k]
+            candidate_count = min(top_k, len(similarities))
+            top_indices = np.argpartition(similarities, -candidate_count)[-candidate_count:]
+            top_indices = top_indices[np.argsort(similarities[top_indices])[::-1]]
 
             similar = []
             for idx in top_indices:
                 if similarities[idx] > 0.4:  # Minimum similarity threshold
                     similar.append(self.examples[idx])
 
+            self._similarity_cache[cache_key] = similar
+            if len(self._similarity_cache) > self._similarity_cache_max_entries:
+                self._similarity_cache.pop(next(iter(self._similarity_cache)))
             return similar
         except Exception as e:
             logger.warning(f"[Learning] Similarity search failed: {e}")

--- a/tests/test_learning_engine_optimizations.py
+++ b/tests/test_learning_engine_optimizations.py
@@ -1,0 +1,112 @@
+from ai.learning.learning_engine import LearningEngine, TrainingExample
+
+
+class _FakeVector:
+    def __init__(self, values):
+        self.values = list(values)
+
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return _FakeVector(self.values[item])
+        if isinstance(item, _FakeVector):
+            return _FakeVector([self.values[i] for i in item.values])
+        if isinstance(item, list):
+            return _FakeVector([self.values[i] for i in item])
+        return self.values[item]
+
+    def __iter__(self):
+        return iter(self.values)
+
+
+class _FakeMatrix:
+    def __init__(self, rows):
+        self.rows = [_FakeVector(r) for r in rows]
+
+    def __getitem__(self, idx):
+        return self.rows[idx]
+
+
+class _FakeNP:
+    @staticmethod
+    def argpartition(values, kth):
+        base = values.values if isinstance(values, _FakeVector) else values
+        indexed = list(enumerate(base))
+        indexed.sort(key=lambda item: item[1])
+        return _FakeVector([idx for idx, _ in indexed])
+
+    @staticmethod
+    def argsort(values):
+        base = values.values if isinstance(values, _FakeVector) else values
+        return [idx for idx, _ in sorted(enumerate(base), key=lambda item: item[1])]
+
+
+class _StubVectorizer:
+    def __init__(self):
+        self.transform_calls = 0
+        self.fit_calls = 0
+
+    def fit_transform(self, texts):
+        self.fit_calls += 1
+        return _FakeMatrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+    def transform(self, texts):
+        self.transform_calls += 1
+        return _FakeMatrix([[1.0, 0.0, 0.0]])
+
+
+def test_similarity_lookup_uses_query_cache(monkeypatch, tmp_path):
+    engine = LearningEngine(data_dir=str(tmp_path / "training"))
+    stub_vectorizer = _StubVectorizer()
+
+    engine.examples = [
+        TrainingExample("alpha", "r1"),
+        TrainingExample("beta", "r2"),
+        TrainingExample("gamma", "r3"),
+    ]
+    engine.vectorizer = stub_vectorizer
+    engine._needs_refit = True
+
+    monkeypatch.setattr("ai.learning.learning_engine._ml_available", lambda: True)
+    monkeypatch.setattr("ai.learning.learning_engine.np", _FakeNP())
+    monkeypatch.setattr(
+        "ai.learning.learning_engine.cosine_similarity",
+        lambda _query, _matrix: _FakeMatrix([[0.9, 0.1, 0.2]]),
+    )
+
+    first = engine.get_similar_examples("alpha", top_k=2)
+    second = engine.get_similar_examples("alpha", top_k=2)
+
+    assert [ex.user_input for ex in first] == ["alpha"]
+    assert [ex.user_input for ex in second] == ["alpha"]
+    assert stub_vectorizer.transform_calls == 1
+
+
+def test_similarity_cache_invalidates_after_collect(monkeypatch, tmp_path):
+    engine = LearningEngine(data_dir=str(tmp_path / "training"))
+    stub_vectorizer = _StubVectorizer()
+
+    engine.examples = [
+        TrainingExample("alpha", "r1"),
+        TrainingExample("beta", "r2"),
+        TrainingExample("gamma", "r3"),
+    ]
+    engine.vectorizer = stub_vectorizer
+    engine._needs_refit = True
+
+    monkeypatch.setattr("ai.learning.learning_engine._ml_available", lambda: True)
+    monkeypatch.setattr("ai.learning.learning_engine.np", _FakeNP())
+    monkeypatch.setattr(
+        "ai.learning.learning_engine.cosine_similarity",
+        lambda _query, _matrix: _FakeMatrix([[0.9, 0.1, 0.2]]),
+    )
+
+    engine.get_similar_examples("alpha", top_k=2)
+    assert stub_vectorizer.transform_calls == 1
+
+    engine.collect_interaction("delta", "r4")
+    engine.vectorizer = stub_vectorizer
+    engine.get_similar_examples("alpha", top_k=2)
+    assert stub_vectorizer.transform_calls == 2


### PR DESCRIPTION
### Motivation
- Reduce repeated vector transforms and similarity scoring for identical similarity queries to improve runtime for the learning service.
- Make top-k selection more efficient for larger example sets by avoiding full-array sorting.
- Ensure cached query results remain consistent after training data changes.

### Description
- Added a bounded in-memory query cache `self._similarity_cache` keyed by `(user_input, top_k)` and `self._similarity_cache_max_entries = 256` to `LearningEngine` and clear it on data changes and refits. 
- In `get_similar_examples` added a cache lookup/insert and LRU-style eviction, an early return for `top_k <= 0`, and cache invalidation from `collect_interaction` and `_refit_vectorizer` via `clear()`.
- Replaced full `argsort` with `np.argpartition` + local `argsort` on the shortlisted candidates to reduce unnecessary work when computing the top-k indices.
- Added `tests/test_learning_engine_optimizations.py` with focused unit tests and lightweight fakes for vectorizer/np/cosine similarity to validate cache hits and cache invalidation without external deps.

### Testing
- Ran `pytest -q tests/test_learning_engine_optimizations.py` under `PYTHONPATH=.`; final run: `2 passed`.
- Earlier automated runs showed environment issues: an initial `pytest -q tests/test_learning_engine_optimizations.py` failed due to import path, and `PYTHONPATH=. pytest -q tests/test_learning_engine_optimizations.py` initially failed because `numpy` was referenced in the test implementation; both issues were resolved by making tests dependency-light and re-running.
- Final automated test run `PYTHONPATH=. pytest -q tests/test_learning_engine_optimizations.py` succeeded with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f0f580b88324af8b6bafba7a94a6)