### PR TITLE
Introduce FoundationLayers and upgrades to NLP, live-state, action recovery, and learning cache

### DIFF
--- a/ai/core/executive_controller.py
+++ b/ai/core/executive_controller.py
@@ -587,8 +587,8 @@ class ExecutiveController:
         has_subject = any(
             cue in low
             for cue in (
-                "jarvis",
-                "tony stark",
+                "assistant",
+                "fictional inventor",
                 "assistant",
                 "technology",
                 "system",
@@ -637,7 +637,7 @@ class ExecutiveController:
             for cue in (
                 "ai",
                 "assistant",
-                "jarvis",
+                "assistant",
                 "system",
                 "architecture",
             )

--- a/ai/core/foundation_layers.py
+++ b/ai/core/foundation_layers.py
@@ -1,0 +1,172 @@
+"""Foundational NLP orchestration layers for agent-grade behavior."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+_FILLER_RE = re.compile(r"\b(?:um+|uh+|er+|ah+|like)\b", re.IGNORECASE)
+_HEDGE_RE = re.compile(r"\b(?:kind of|sort of|i guess|maybe)\b", re.IGNORECASE)
+
+
+@dataclass
+class TurnBudget:
+    started_at: float = field(default_factory=time.perf_counter)
+    budget_ms: float = 120.0
+
+    def elapsed_ms(self) -> float:
+        return (time.perf_counter() - self.started_at) * 1000.0
+
+    def remaining_ms(self) -> float:
+        return max(0.0, self.budget_ms - self.elapsed_ms())
+
+
+@dataclass
+class PlanState:
+    goal: str = ""
+    constraints: Dict[str, Any] = field(default_factory=dict)
+    domain: str = ""
+    turns_seen: int = 0
+
+
+class FoundationLayers:
+    """Small, composable layers for robust assistant routing."""
+
+    def __init__(self, budget_ms: float = 120.0):
+        self._budget_ms = float(budget_ms)
+        self._plan = PlanState()
+        self._metrics = {"turns": 0, "clarifications": 0, "safety_blocks": 0}
+        self._clarification_conf_threshold = 0.58
+        self._clarification_margin_threshold = 0.35
+        self._deep_stage_skip_threshold = 0.95
+
+    # 1) ASR-aware normalization (text-first variant; safe for non-voice input too).
+    def normalize_input(self, text: str) -> str:
+        normalized = str(text or "")
+        normalized = _FILLER_RE.sub(" ", normalized)
+        normalized = _HEDGE_RE.sub(" ", normalized)
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        return normalized
+
+    # 2) Multi-turn plan memory.
+    def update_plan_memory(self, *, intent: str, parsed_command: Dict[str, Any], text: str) -> Dict[str, Any]:
+        self._plan.turns_seen += 1
+        if parsed_command.get("object_type") and parsed_command.get("object_type") != "unknown":
+            self._plan.domain = str(parsed_command.get("object_type"))
+        if parsed_command.get("title_hint"):
+            self._plan.goal = str(parsed_command.get("title_hint"))
+        if "by " in text.lower():
+            self._plan.constraints["deadline_hint"] = text
+        if intent:
+            self._plan.constraints["last_intent"] = intent
+        return {
+            "goal": self._plan.goal,
+            "domain": self._plan.domain,
+            "constraints": dict(self._plan.constraints),
+            "turns_seen": self._plan.turns_seen,
+        }
+
+    # 3) Grounded world-state integration (extensible, no hard dependency).
+    def apply_grounding(self, parsed_command: Dict[str, Any], world_state: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        state = dict(world_state or {})
+        hints = {}
+        if "location" in state:
+            hints["location"] = state["location"]
+        if "timezone" in state:
+            hints["timezone"] = state["timezone"]
+        if hints:
+            parsed_command.setdefault("modifiers", {})["grounding_hints"] = hints
+        return hints
+
+    # 4) Proactive clarification policy.
+    def clarification_policy(self, *, plugin_scores: Dict[str, float], confidence: float) -> Dict[str, Any]:
+        ordered = sorted(plugin_scores.items(), key=lambda x: x[1], reverse=True)
+        top = ordered[0][1] if ordered else 0.0
+        second = ordered[1][1] if len(ordered) > 1 else 0.0
+        margin = top - second
+        needs = bool(
+            confidence < self._clarification_conf_threshold
+            or margin < self._clarification_margin_threshold
+        )
+        if needs:
+            self._metrics["clarifications"] += 1
+        prompt = ""
+        if needs and ordered:
+            top_name = ordered[0][0]
+            second_name = ordered[1][0] if len(ordered) > 1 else "conversation"
+            prompt = (
+                f"I can handle this as {top_name} or {second_name}. "
+                f"Which one do you want?"
+            )
+        return {
+            "needs_clarification": needs,
+            "top_margin": margin,
+            "top_score": top,
+            "prompt": prompt,
+            "thresholds": {
+                "confidence": self._clarification_conf_threshold,
+                "margin": self._clarification_margin_threshold,
+            },
+        }
+
+    def tune_from_outcome(
+        self,
+        *,
+        false_clarification: bool = False,
+        wrong_tool_execution: bool = False,
+    ) -> Dict[str, float]:
+        """Adaptive threshold calibration from runtime outcomes (P0)."""
+        if false_clarification:
+            self._clarification_conf_threshold = max(
+                0.45, self._clarification_conf_threshold - 0.01
+            )
+            self._clarification_margin_threshold = max(
+                0.20, self._clarification_margin_threshold - 0.01
+            )
+        if wrong_tool_execution:
+            self._clarification_conf_threshold = min(
+                0.75, self._clarification_conf_threshold + 0.02
+            )
+            self._clarification_margin_threshold = min(
+                0.50, self._clarification_margin_threshold + 0.015
+            )
+        return {
+            "confidence": round(self._clarification_conf_threshold, 4),
+            "margin": round(self._clarification_margin_threshold, 4),
+        }
+
+    # 5) Evaluation harness (online turn metrics).
+    def record_turn(self, *, confidence: float, clarification: bool, safety_blocked: bool) -> Dict[str, Any]:
+        self._metrics["turns"] += 1
+        if safety_blocked:
+            self._metrics["safety_blocks"] += 1
+        return {
+            "turns": self._metrics["turns"],
+            "clarifications": self._metrics["clarifications"] + (1 if clarification else 0),
+            "safety_blocks": self._metrics["safety_blocks"],
+            "last_confidence": float(confidence),
+        }
+
+    # 6) Latency budget + staged inference.
+    def new_budget(self) -> TurnBudget:
+        return TurnBudget(budget_ms=self._budget_ms)
+
+    def should_run_deep_stage(self, budget: TurnBudget, *, shallow_confidence: float) -> bool:
+        if shallow_confidence >= self._deep_stage_skip_threshold:
+            return False
+        return budget.remaining_ms() > 20.0
+
+    # 7) Safety / authorization gate.
+    def authorization_policy(self, *, intent: str, text: str) -> Dict[str, Any]:
+        low = (text or "").lower()
+        high_risk_intents = {"system:shutdown", "system:reboot", "email:delete", "notes:delete"}
+        high_risk_language = {"delete all", "wipe", "format", "shutdown", "reboot"}
+        blocked = intent in high_risk_intents or any(cue in low for cue in high_risk_language)
+        return {
+            "allowed": not blocked,
+            "requires_confirmation": blocked,
+            "reason": "high_risk_action" if blocked else "allowed",
+        }

--- a/ai/core/live_state_service.py
+++ b/ai/core/live_state_service.py
@@ -21,11 +21,17 @@ class LiveSnapshot:
 class LiveStateService:
     """Builds fresh snapshots from multiple state stores."""
 
+    FRESHNESS_TTL_SECONDS = {
+        "weather": 1800.0,
+        "forecast": 3600.0,
+    }
+
     def freshest_weather_snapshot(
         self,
         *,
         reasoning_engine: Any = None,
         world_state_memory: Any = None,
+        max_age_seconds: Optional[float] = None,
     ) -> Optional[Dict[str, Any]]:
         candidates = []
 
@@ -45,10 +51,20 @@ class LiveStateService:
             return None
 
         freshest = max(candidates, key=lambda x: float(x.captured_at or 0.0))
+        ttl = float(
+            max_age_seconds
+            if max_age_seconds is not None
+            else self.FRESHNESS_TTL_SECONDS["weather"]
+        )
+        age_seconds = max(0.0, self._to_epoch(datetime.utcnow()) - float(freshest.captured_at or 0.0))
+        is_stale = age_seconds > ttl if freshest.captured_at else True
         return {
             "source": freshest.source,
             "captured_at": freshest.captured_at,
             "data": dict(freshest.data or {}),
+            "age_seconds": age_seconds,
+            "is_stale": is_stale,
+            "ttl_seconds": ttl,
         }
 
     def latest_weather_forecast(
@@ -56,6 +72,7 @@ class LiveStateService:
         *,
         reasoning_engine: Any = None,
         world_state_memory: Any = None,
+        max_age_seconds: Optional[float] = None,
     ) -> Optional[Dict[str, Any]]:
         candidates = []
         forecast = self._from_reasoning_entity(reasoning_engine, "weather_forecast")
@@ -70,7 +87,17 @@ class LiveStateService:
             return None
 
         freshest = max(candidates, key=lambda x: float(x.captured_at or 0.0))
-        return dict(freshest.data or {})
+        payload = dict(freshest.data or {})
+        ttl = float(
+            max_age_seconds
+            if max_age_seconds is not None
+            else self.FRESHNESS_TTL_SECONDS["forecast"]
+        )
+        age_seconds = max(0.0, self._to_epoch(datetime.utcnow()) - float(freshest.captured_at or 0.0))
+        payload["age_seconds"] = age_seconds
+        payload["is_stale"] = age_seconds > ttl if freshest.captured_at else True
+        payload["ttl_seconds"] = ttl
+        return payload
 
     def _from_reasoning_entity(
         self, reasoning_engine: Any, entity_id: str

--- a/ai/core/nlp_processor.py
+++ b/ai/core/nlp_processor.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Optional, Tuple, Any, Set
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import math
-from collections import OrderedDict, defaultdict, deque
+from collections import OrderedDict, defaultdict, deque, Counter
 from pathlib import Path
 import threading
 
@@ -143,6 +143,7 @@ from ai.core.perception import Perception, PerceptionResult
 from ai.core.followup_resolver import FollowUpResolver, FollowUpResult
 from ai.core.route_coordinator import RouteCoordinator, RouteCoordinatorConfig
 from ai.core.goal_recognizer import get_goal_recognizer
+from ai.core.foundation_layers import FoundationLayers
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +157,33 @@ _NEGATION_WORDS: frozenset = frozenset({
     "can't", "cant", "stop", "isn't", "isnt", "aren't", "arent",
     "didn't", "didnt", "wouldn't", "wouldnt", "shouldn't", "shouldnt",
 })
+
+_TOKEN_PATTERN = re.compile(r'"[^"]+"|#\w+|\d+(?:st|nd|rd|th)?|[A-Za-z]+|[^\w\s]')
+_ORDINAL_TOKEN_RE = re.compile(r"\d+(?:st|nd|rd|th)")
+_ALPHA_TOKEN_RE = re.compile(r"[A-Za-z]+")
+
+_NOTE_TERMS: frozenset = frozenset({"note", "notes", "list", "lists", "todo", "task", "tasks"})
+_EMAIL_TERMS: frozenset = frozenset({"email", "emails", "mail", "inbox", "sender", "subject"})
+_CALENDAR_TERMS: frozenset = frozenset({"calendar", "event", "events", "meeting", "schedule"})
+_WEATHER_TERMS: frozenset = frozenset({
+    "weather", "forecast", "temperature", "rain", "snow", "sunny", "cloudy", "overcast",
+    "wind", "windy", "storm", "humidity", "humid", "outside", "precipitation",
+    "precip", "drizzle", "thunder", "thunderstorm",
+})
+_WEATHER_FORECAST_TERMS: frozenset = frozenset({
+    "tomorrow", "tonight", "week", "weekend", "forecast", "monday", "tuesday",
+    "wednesday", "thursday", "friday", "saturday", "sunday", "chance", "expect", "later",
+})
+_WEATHER_EVENT_TERMS: frozenset = frozenset({"snow", "rain", "storm", "drizzle", "thunder"})
+_WEATHER_FUTURE_TERMS: frozenset = frozenset({"will", "gonna", "going", "chance", "expect", "is"})
+_SYSTEM_TERMS: frozenset = frozenset({"system", "cpu", "memory", "disk", "battery", "status"})
+_NON_WEATHER_TARGET_TERMS: frozenset = frozenset({
+    "note", "notes", "memo", "email", "emails", "mail", "calendar", "event", "events", "meeting",
+})
+_WAKE_WORD_PREFIX_RE = re.compile(
+    r"^\s*(?:hey|ok|okay)?\s*(?:assistant|alice)\b[\s,:\-]*",
+    re.IGNORECASE,
+)
 
 
 def _has_negation_before(text_lower: str, keyword: str, window_chars: int = 40) -> bool:
@@ -1241,6 +1269,7 @@ class NLPProcessor:
                 conversation_category_gate_threshold=self.CONVERSATION_CATEGORY_GATE_THRESHOLD,
             )
         )
+        self.foundation_layers = FoundationLayers(budget_ms=120.0)
 
         # Tier foundations: explicit short-horizon memory + implicit intent + dialogue state machine
         if INTELLIGENCE_FOUNDATIONS_AVAILABLE:
@@ -2165,8 +2194,8 @@ class NLPProcessor:
             return False
 
         subject_cues = {
-            "jarvis",
-            "tony stark",
+            "assistant",
+            "fictional inventor",
             "assistant",
             "ai",
             "technology",
@@ -2217,7 +2246,7 @@ class NLPProcessor:
             for cue in (
                 "ai",
                 "assistant",
-                "jarvis",
+                "assistant",
                 "system",
                 "architecture",
             )
@@ -2437,6 +2466,7 @@ class NLPProcessor:
         """Normalize user input before lexical tokenization."""
         normalized = (text or "").strip()
         normalized = re.sub(r"\s+", " ", normalized)
+        normalized = _WAKE_WORD_PREFIX_RE.sub("", normalized, count=1).strip()
 
         contractions = {
             "what's": "what is",
@@ -2479,9 +2509,6 @@ class NLPProcessor:
     def _lexical_tokenize(self, segments: List[TokenSegment]) -> List[RichToken]:
         """Lexical layer: tokenize segments into rich tokens with type/role/span metadata."""
         tokens: List[RichToken] = []
-        token_pattern = re.compile(
-            r'"[^"]+"|#\w+|\d+(?:st|nd|rd|th)?|[A-Za-z]+|[^\w\s]'
-        )
 
         action_words = self.command_vocabulary.get("verbs", set())
         object_words = self.command_vocabulary.get("objects", set())
@@ -2501,7 +2528,7 @@ class NLPProcessor:
         meta_words = self.command_vocabulary.get("meta", set())
 
         for segment in segments:
-            for match in token_pattern.finditer(segment.text):
+            for match in _TOKEN_PATTERN.finditer(segment.text):
                 raw = match.group(0)
                 norm = raw.lower()
                 start = segment.start_pos + match.start()
@@ -2513,13 +2540,13 @@ class NLPProcessor:
                 elif raw.startswith("#"):
                     kind = "hashtag"
                     role = "modifier"
-                elif re.fullmatch(r"\d+(?:st|nd|rd|th)", norm):
+                elif _ORDINAL_TOKEN_RE.fullmatch(norm):
                     kind = "ordinal"
                     role = "reference"
                 elif raw.isdigit():
                     kind = "number"
                     role = "value"
-                elif re.fullmatch(r"[A-Za-z]+", raw):
+                elif _ALPHA_TOKEN_RE.fullmatch(raw):
                     kind = "word"
                     if norm in action_words:
                         role = "action"
@@ -2675,62 +2702,21 @@ class NLPProcessor:
         }
 
         normalized = [token.normalized for token in tokens]
+        token_counts = Counter(normalized)
+        normalized_set = set(token_counts.keys())
         bigrams = {
             f"{normalized[i]} {normalized[i + 1]}" for i in range(len(normalized) - 1)
         }
-        note_terms = {"note", "notes", "list", "lists", "todo", "task", "tasks"}
-        email_terms = {"email", "emails", "mail", "inbox", "sender", "subject"}
-        cal_terms = {"calendar", "event", "events", "meeting", "schedule"}
-        weather_terms = {
-            "weather",
-            "forecast",
-            "temperature",
-            "rain",
-            "snow",
-            "sunny",
-            "cloudy",
-            "overcast",
-            "wind",
-            "windy",
-            "storm",
-            "humidity",
-            "humid",
-            "outside",
-            "precipitation",
-            "precip",
-            "drizzle",
-            "thunder",
-            "thunderstorm",
-        }
-        weather_forecast_terms = {
-            "tomorrow",
-            "tonight",
-            "week",
-            "weekend",
-            "forecast",
-            "monday",
-            "tuesday",
-            "wednesday",
-            "thursday",
-            "friday",
-            "saturday",
-            "sunday",
-            "chance",
-            "expect",
-            "later",
-        }
-        system_terms = {"system", "cpu", "memory", "disk", "battery", "status"}
-
-        scores["notes"] += sum(1.2 for word in normalized if word in note_terms)
-        scores["email"] += sum(1.2 for word in normalized if word in email_terms)
-        scores["calendar"] += sum(1.2 for word in normalized if word in cal_terms)
-        scores["weather"] += sum(1.35 for word in normalized if word in weather_terms)
-        scores["system"] += sum(1.2 for word in normalized if word in system_terms)
-        if any(word in normalized for word in weather_forecast_terms):
+        scores["notes"] += 1.2 * sum(token_counts[word] for word in _NOTE_TERMS)
+        scores["email"] += 1.2 * sum(token_counts[word] for word in _EMAIL_TERMS)
+        scores["calendar"] += 1.2 * sum(token_counts[word] for word in _CALENDAR_TERMS)
+        scores["weather"] += 1.35 * sum(token_counts[word] for word in _WEATHER_TERMS)
+        scores["system"] += 1.2 * sum(token_counts[word] for word in _SYSTEM_TERMS)
+        if _WEATHER_FORECAST_TERMS & normalized_set:
             scores["weather"] += 0.8
         if (
-            any(word in normalized for word in {"snow", "rain", "storm", "drizzle", "thunder"})
-            and any(word in normalized for word in {"will", "gonna", "going", "chance", "expect", "is"})
+            _WEATHER_EVENT_TERMS & normalized_set
+            and _WEATHER_FUTURE_TERMS & normalized_set
         ):
             scores["weather"] += 0.9
 
@@ -2793,22 +2779,8 @@ class NLPProcessor:
             scores[preferred] += 0.45
 
         # Strong weather language should outrank weak lexical collisions in notes/email/calendar.
-        weather_signal_strength = sum(1 for word in normalized if word in weather_terms)
-        has_explicit_non_weather_target = bool(
-            set(normalized)
-            & {
-                "note",
-                "notes",
-                "memo",
-                "email",
-                "emails",
-                "mail",
-                "calendar",
-                "event",
-                "events",
-                "meeting",
-            }
-        )
+        weather_signal_strength = sum(token_counts[word] for word in _WEATHER_TERMS)
+        has_explicit_non_weather_target = bool(normalized_set & _NON_WEATHER_TARGET_TERMS)
         if weather_signal_strength >= 1 and not has_explicit_non_weather_target:
             scores["notes"] *= 0.35
             scores["email"] *= 0.45
@@ -2947,6 +2919,7 @@ class NLPProcessor:
         8. Extract keywords
         9. Update conversation context
         """
+        turn_budget = self.foundation_layers.new_budget()
 
         # Step 1: Coreference resolution
         if use_context:
@@ -3000,6 +2973,7 @@ class NLPProcessor:
 
         # Step 2: Clean + normalize for tokenizer layers
         clean_text = self._clean_text(resolved_text)
+        clean_text = self.foundation_layers.normalize_input(clean_text)
         normalized_text = self._normalize_for_tokenizer(clean_text)
         contextual_text = normalized_text
         if self.conversation_memory is not None:
@@ -3139,15 +3113,29 @@ class NLPProcessor:
                     trace={"source": "retrieval_first"},
                 )
             else:
-                semantic_intent = self._detect_intent_semantic(
-                    contextual_text,
-                    parsed_command=parsed_command,
-                    plugin_scores=plugin_scores,
-                    return_structured=False,
-                )
                 weighted_candidates = self._build_weighted_parse(
                     parsed_command, plugin_scores, normalized_text
                 )
+                shallow_confidence = max(plugin_scores.values()) if plugin_scores else 0.0
+                run_deep_stage = self.foundation_layers.should_run_deep_stage(
+                    turn_budget, shallow_confidence=shallow_confidence
+                )
+                if parsed_command.sentence_type == "question":
+                    run_deep_stage = True
+                parsed_command.modifiers["staged_inference"] = {
+                    "deep_stage_enabled": run_deep_stage,
+                    "elapsed_ms": round(turn_budget.elapsed_ms(), 3),
+                    "shallow_confidence": round(float(shallow_confidence), 3),
+                }
+                if run_deep_stage:
+                    semantic_intent = self._detect_intent_semantic(
+                        contextual_text,
+                        parsed_command=parsed_command,
+                        plugin_scores=plugin_scores,
+                        return_structured=False,
+                    )
+                else:
+                    semantic_intent = None
 
                 if self.implicit_intent_detector is not None:
                     _implicit_matches = self.implicit_intent_detector.detect(
@@ -3204,6 +3192,22 @@ class NLPProcessor:
             normalized_text=normalized_text,
             intent=intent,
         )
+
+        clarification_state = self.foundation_layers.clarification_policy(
+            plugin_scores=plugin_scores,
+            confidence=float(intent_confidence or 0.0),
+        )
+        parsed_command.modifiers["clarification_policy"] = clarification_state
+
+        authorization = self.foundation_layers.authorization_policy(
+            intent=intent,
+            text=normalized_text,
+        )
+        parsed_command.modifiers["authorization"] = authorization
+        if not authorization.get("allowed", True):
+            intent = "conversation:clarification_needed"
+            intent_confidence = min(float(intent_confidence or 0.0), 0.45)
+            parsed_command.modifiers["tool_execution_disabled"] = True
 
         # Fingerprint prior: if we have a cached high-confidence parse, use it as a boost
         if (
@@ -3711,6 +3715,17 @@ class NLPProcessor:
             # Feature disabled for A/B testing
             pass
 
+        # Final authorization check after all route/frame overrides
+        authorization = self.foundation_layers.authorization_policy(
+            intent=intent,
+            text=normalized_text,
+        )
+        parsed_command.modifiers["authorization"] = authorization
+        if not authorization.get("allowed", True):
+            intent = "conversation:clarification_needed"
+            intent_confidence = min(float(intent_confidence or 0.0), 0.45)
+            parsed_command.modifiers["tool_execution_disabled"] = True
+
         # Step 5: Sentiment analysis
         if self.sentiment_analyzer is not None:
             sentiment = self.sentiment_analyzer.polarity_scores(normalized_text)
@@ -3763,6 +3778,30 @@ class NLPProcessor:
         ):
             # Feature disabled for A/B testing
             pass
+
+        plan_snapshot = self.foundation_layers.update_plan_memory(
+            intent=intent,
+            parsed_command=parsed_command.__dict__,
+            text=normalized_text,
+        )
+        parsed_command.modifiers["plan_memory"] = plan_snapshot
+        self.foundation_layers.apply_grounding(
+            parsed_command.__dict__,
+            world_state={
+                "location": (self.context.last_entities or {}).get("location"),
+                "timezone": "UTC",
+            },
+        )
+        eval_snapshot = self.foundation_layers.record_turn(
+            confidence=float(intent_confidence or 0.0),
+            clarification=bool(clarification_state.get("needs_clarification")),
+            safety_blocked=not authorization.get("allowed", True),
+        )
+        parsed_command.modifiers["evaluation_harness"] = eval_snapshot
+        parsed_command.modifiers["latency_budget"] = {
+            "elapsed_ms": round(turn_budget.elapsed_ms(), 3),
+            "remaining_ms": round(turn_budget.remaining_ms(), 3),
+        }
 
         # Build result
         result = ProcessedQuery(

--- a/ai/core/unified_action_engine.py
+++ b/ai/core/unified_action_engine.py
@@ -286,6 +286,11 @@ class UnifiedActionEngine:
                 retry_budget=request.retry_budget,
                 partial_success=bool(goal_report.get("partial_success", False)),
             )
+            recommendation = self._recommend_recovery_plan(
+                request=request,
+                result_dict=result_dict,
+                attempt_idx=attempt_idx,
+            )
 
             last_result = ActionResult(
                 success=success,
@@ -311,6 +316,12 @@ class UnifiedActionEngine:
                 recovery_path=recovery_path,
                 retry_count=attempt_idx,
             )
+            if recommendation:
+                last_result.state_updates["recovery_recommendation"] = recommendation
+                if not last_result.recovery_path:
+                    last_result.recovery_path = str(
+                        recommendation.get("next_step") or "clarify_then_continue"
+                    )
 
             self._record_journal(
                 "attempt",
@@ -442,6 +453,31 @@ class UnifiedActionEngine:
         request.rollback_policy = str(request.rollback_policy or "none").strip().lower()
         request.plan_steps = list(request.plan_steps or [])
         return request
+
+    def _recommend_recovery_plan(
+        self,
+        *,
+        request: ActionRequest,
+        result_dict: Dict[str, Any],
+        attempt_idx: int,
+    ) -> Dict[str, Any]:
+        """P0 recovery planner: deterministic next-step guidance for failed actions."""
+        if bool(result_dict.get("success", False)):
+            return {}
+        if attempt_idx < int(request.retry_budget or 0):
+            return {
+                "next_step": "retry_with_adjusted_params",
+                "reason": "retry_budget_remaining",
+            }
+        if not (request.target_spec or {}).get("target"):
+            return {
+                "next_step": "request_target_clarification",
+                "reason": "missing_target_spec",
+            }
+        return {
+            "next_step": "try_alternative_action",
+            "reason": "retry_exhausted_with_target_present",
+        }
 
     def _request_goal_id(self, request: ActionRequest) -> str:
         if request.goal_ref is None:

--- a/ai/learning/learning_engine.py
+++ b/ai/learning/learning_engine.py
@@ -109,6 +109,8 @@ class LearningEngine:
 
         self._tfidf_matrix = None
         self._needs_refit = True
+        self._similarity_cache: Dict[Tuple[str, int], List[TrainingExample]] = {}
+        self._similarity_cache_max_entries = 256
 
         # Storage
         self.training_file = self.data_dir / "training_data.jsonl"
@@ -196,6 +198,7 @@ class LearningEngine:
 
             # Mark TF-IDF matrix as needing refit after new example
             self._needs_refit = True
+            self._similarity_cache.clear()
 
     def run_offline_training(self, max_entries: int = 500) -> Dict[str, Any]:
         """
@@ -320,6 +323,7 @@ class LearningEngine:
         texts = [ex.user_input for ex in self.examples]
         self._tfidf_matrix = self.vectorizer.fit_transform(texts)
         self._needs_refit = False
+        self._similarity_cache.clear()
 
     def _learn_pattern(self, example: TrainingExample):
         """Learn a single pattern"""
@@ -344,8 +348,15 @@ class LearningEngine:
             return []
         if len(self.examples) < 2:
             return []
+        if top_k <= 0:
+            return []
 
         try:
+            cache_key = (user_input, top_k)
+            cached = self._similarity_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
             # Refit the shared vectorizer only when examples have changed
             if self._needs_refit:
                 self._refit_vectorizer()
@@ -353,13 +364,18 @@ class LearningEngine:
             # Transform only the query using the already-fitted vectorizer
             query_vec = self.vectorizer.transform([user_input])
             similarities = cosine_similarity(query_vec, self._tfidf_matrix)[0]
-            top_indices = np.argsort(similarities)[::-1][:top_k]
+            candidate_count = min(top_k, len(similarities))
+            top_indices = np.argpartition(similarities, -candidate_count)[-candidate_count:]
+            top_indices = top_indices[np.argsort(similarities[top_indices])[::-1]]
 
             similar = []
             for idx in top_indices:
                 if similarities[idx] > 0.4:  # Minimum similarity threshold
                     similar.append(self.examples[idx])
 
+            self._similarity_cache[cache_key] = similar
+            if len(self._similarity_cache) > self._similarity_cache_max_entries:
+                self._similarity_cache.pop(next(iter(self._similarity_cache)))
             return similar
         except Exception as e:
             logger.warning(f"[Learning] Similarity search failed: {e}")

--- a/ai/roadmap/assistant_foundation_next_steps.md
+++ b/ai/roadmap/assistant_foundation_next_steps.md
@@ -1,0 +1,186 @@
+# A.L.I.C.E → Advanced Assistant Foundation Next Steps
+
+This plan is based on the current architecture and code paths in:
+
+- `ai/core/nlp_processor.py`
+- `ai/core/foundation_layers.py`
+- `ai/core/unified_action_engine.py`
+- `ai/core/cognitive_orchestrator.py`
+- `ai/core/world_state_memory.py`
+- `ai/core/live_state_service.py`
+
+The goal is not "voice gimmicks" yet; it is *agent reliability + autonomy quality*.
+
+---
+
+## P0 (Highest Impact, Do Next)
+
+### 1) Intent Calibration + Guardrails: learn from mistakes automatically
+**Why now**
+- NLP now has staged inference and clarification policy, but thresholds are mostly static.
+
+**Implement**
+- Add an online threshold tuner that adjusts:
+  - `clarification_policy` confidence and margin cutoffs
+  - `should_run_deep_stage` gate in `FoundationLayers`
+- Feed it data from:
+  - false clarification triggers
+  - wrong-tool executions
+  - user corrections
+
+**Where**
+- `ai/core/foundation_layers.py`
+- `ai/core/nlp_processor.py`
+- `ai/core/adaptive_intent_calibrator.py` (already exists; extend usage)
+
+---
+
+### 2) World-state freshness contracts for tool answers
+**Why now**
+- `LiveStateService` has snapshot selection logic, but no strict freshness policy per domain.
+
+**Implement**
+- Add per-domain TTL + staleness policy:
+  - weather, calendar, system metrics
+- If stale:
+  - force refresh
+  - or respond with explicit stale warning
+
+**Where**
+- `ai/core/live_state_service.py`
+- `ai/core/world_state_memory.py`
+- action flow integration in `ai/core/unified_action_engine.py`
+
+---
+
+### 3) Recovery planner for failed actions
+**Why now**
+- `UnifiedActionEngine` already has rollback and retry structure.
+- Missing: deterministic multi-step "what to try next".
+
+**Implement**
+- Add a recovery policy graph:
+  - retry with adjusted params
+  - alternative plugin/action
+  - ask targeted clarification
+- Persist attempted recovery paths in journal and world state.
+
+**Where**
+- `ai/core/unified_action_engine.py`
+- `ai/core/rollback_executor.py`
+- `ai/core/execution_journal.py`
+
+---
+
+## P1 (Second Wave)
+
+### 4) Goal decomposition and continuity across turns
+**Why now**
+- `CognitiveOrchestrator` tracks long-horizon goals, but execution-level decomposition can be tighter.
+
+**Implement**
+- Convert high-level goals into explicit step graphs with completion criteria.
+- Store progress and blockers in world-state memory.
+
+**Where**
+- `ai/core/cognitive_orchestrator.py`
+- `ai/core/goal_tracker.py`
+- `ai/core/world_state_memory.py`
+
+---
+
+### 5) Clarification UX upgrades (short, high-information prompts)
+**Why now**
+- Clarification exists, but you can make it feel more "operator-grade":
+  - concise
+  - optioned
+  - context aware
+
+**Implement**
+- Clarification templates that include:
+  - top 2 likely interpretations
+  - exactly one follow-up question
+  - recommended default
+
+**Where**
+- `ai/core/foundation_layers.py`
+- `ai/core/clarification_resolver.py`
+- `ai/core/route_coordinator.py`
+
+---
+
+### 6) Policy simulation before risky execution
+**Why now**
+- Action engine has simulation gates; deepen them for high-risk domains.
+
+**Implement**
+- Run "dry-run simulation" for:
+  - delete/update actions
+  - broad system commands
+- Require either:
+  - explicit confirmation
+  - or low-risk verification score
+
+**Where**
+- `ai/core/unified_action_engine.py`
+- `ai/core/goal_action_verifier.py`
+- `ai/core/execution_verifier.py`
+
+---
+
+## P2 (Stability + Productization)
+
+### 7) Eval harness expansion (agent benchmarks, not just unit tests)
+**Why now**
+- You have many integration tests already. Convert them into KPI-style dashboards.
+
+**Implement**
+- Nightly benchmark suite:
+  - route accuracy
+  - tool success rate
+  - recovery success rate
+  - clarification precision/recall
+  - latency buckets (P50/P95)
+
+**Where**
+- `tools/auditing/core_benchmark_gate.py`
+- `tests/integration/*`
+- `scripts/automation/nightly_audit_scheduler.py`
+
+---
+
+### 8) Personalization and operator style model
+**Why now**
+- High-quality assistant feel = predictable personalization.
+
+**Implement**
+- Add stable user preference profile:
+  - response brevity
+  - preferred confirmation style
+  - risk tolerance
+- Use profile in response planner and routing.
+
+**Where**
+- `ai/core/adaptive_response_style.py`
+- `ai/runtime/user_state_model.py`
+- `ai/core/response_planner.py`
+
+---
+
+## Suggested execution order (4 sprints)
+
+1. **Sprint 1**: P0-1 (intent calibration), P0-2 (freshness contracts)  
+2. **Sprint 2**: P0-3 (recovery planner), P1-5 (clarification UX)  
+3. **Sprint 3**: P1-4 (goal decomposition), P1-6 (risk simulation hardening)  
+4. **Sprint 4**: P2-7 (benchmark KPI pipeline), P2-8 (personalization model)
+
+---
+
+## Definition of "closer to advanced assistant quality" (measurable)
+
+- Clarification precision > 85%
+- Wrong-tool execution rate < 3%
+- Recovery success after first failure > 70%
+- Stale-state answer rate < 2%
+- P95 routing latency < 200ms (without LLM generation)
+- Multi-turn task completion rate +20% over current baseline

--- a/ai/runtime/user_state_model.py
+++ b/ai/runtime/user_state_model.py
@@ -19,6 +19,13 @@ class UserState:
     last_route: str = ""
     last_intent: str = ""
     world_state_snapshot: Dict[str, Any] = field(default_factory=dict)
+    preferences: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "response_brevity": "balanced",
+            "confirmation_style": "safety_first",
+            "risk_tolerance": "medium",
+        }
+    )
     updated_at: str = ""
 
 
@@ -62,5 +69,24 @@ class UserStateModel:
             state.last_result_produced = str(last_result_produced)
         if world_state_snapshot is not None:
             state.world_state_snapshot = dict(world_state_snapshot)
+        state.updated_at = datetime.utcnow().isoformat()
+        return state
+
+    def update_preferences(
+        self,
+        *,
+        user_id: str,
+        response_brevity: Optional[str] = None,
+        confirmation_style: Optional[str] = None,
+        risk_tolerance: Optional[str] = None,
+    ) -> UserState:
+        """P2 personalization profile updates."""
+        state = self.get_or_create(user_id)
+        if response_brevity:
+            state.preferences["response_brevity"] = str(response_brevity)
+        if confirmation_style:
+            state.preferences["confirmation_style"] = str(confirmation_style)
+        if risk_tolerance:
+            state.preferences["risk_tolerance"] = str(risk_tolerance)
         state.updated_at = datetime.utcnow().isoformat()
         return state

--- a/app/main.py
+++ b/app/main.py
@@ -4593,8 +4593,8 @@ class ALICE:
         has_subject = any(
             cue in text
             for cue in (
-                "jarvis",
-                "tony stark",
+                "assistant",
+                "fictional inventor",
                 "assistant",
                 "technology",
                 "system",
@@ -4643,7 +4643,7 @@ class ALICE:
             for cue in (
                 "ai",
                 "assistant",
-                "jarvis",
+                "assistant",
                 "system",
                 "architecture",
             )
@@ -4952,7 +4952,7 @@ class ALICE:
 
         domain_markers = {
             "nlp": ["nlp", "natural language", "intent", "entity", "embedding", "token"],
-            "assistant": ["assistant", "jarvis", "copilot", "agent"],
+            "assistant": ["assistant", "assistant", "copilot", "agent"],
             "machine_learning": ["machine learning", "ml", "classification", "regression"],
             "ai": ["ai", "artificial intelligence", "llm", "rag"],
             "python": ["python", "fastapi", "flask", "django"],

--- a/tests/integration/test_executive_control_layer.py
+++ b/tests/integration/test_executive_control_layer.py
@@ -649,7 +649,7 @@ def test_simple_conversational_prompts_force_native_direct_path(utterance: str, 
 def test_pre_route_guard_allows_rich_conceptual_prompt_even_when_plausibility_is_low() -> None:
     controller = ExecutiveController()
     state = controller.build_state(
-        user_input="let's imagine how jarvis would be created with today's technology no fiction",
+        user_input="let's imagine how assistant would be created with today's technology no fiction",
         intent="notes:list",
         confidence=0.40,
         entities={"_intent_plausibility": 0.31},
@@ -672,7 +672,7 @@ def test_pre_route_guard_allows_rich_conceptual_prompt_even_when_plausibility_is
 def test_rich_conceptual_prompt_with_clarification_intent_prefers_direct_answer_mode() -> None:
     controller = ExecutiveController()
     state = controller.build_state(
-        user_input="let's imagine how jarvis would be created with today's technology no fiction",
+        user_input="let's imagine how assistant would be created with today's technology no fiction",
         intent="conversation:clarification_needed",
         confidence=0.63,
         entities={"_intent_plausibility": 0.55},
@@ -694,7 +694,7 @@ def test_rich_conceptual_prompt_with_clarification_intent_prefers_direct_answer_
 def test_rich_conceptual_build_prompt_with_clarification_bias_still_uses_fresh_reasoning() -> None:
     controller = ExecutiveController()
     state = controller.build_state(
-        user_input="how can i create an ai just like jarvis but with todays technology",
+        user_input="how can i create an ai just like assistant but with todays technology",
         intent="conversation:clarification_needed",
         confidence=0.52,
         entities={"_intent_plausibility": 0.44},

--- a/tests/integration/test_nlp_tokenizer_layers.py
+++ b/tests/integration/test_nlp_tokenizer_layers.py
@@ -9,9 +9,9 @@ sys.path.insert(0, str(project_root))
 from ai.core.nlp_processor import NLPProcessor, ParsedCommand
 
 
-EXACT_LOG_PROMPT = "let's imagine how jarvis would be created with today's technology no fiction"
-EXACT_TONY_PROMPT = "let's imagine how tony stark would have created Jarvis with todays technology, no fiction"
-EXACT_CREATE_PROMPT = "how can i create an ai just like jarvis but with todays technology"
+EXACT_LOG_PROMPT = "let's imagine how assistant would be created with today's technology no fiction"
+EXACT_TONY_PROMPT = "let's imagine how fictional inventor would have created assistant with todays technology, no fiction"
+EXACT_CREATE_PROMPT = "how can i create an ai just like assistant but with todays technology"
 
 
 class TestLayeredTokenizer:

--- a/tests/integration/test_semantic_fidelity_regression.py
+++ b/tests/integration/test_semantic_fidelity_regression.py
@@ -11,9 +11,9 @@ EXACT_PROMPT = (
     "in today's world with no fiction"
 )
 
-EXACT_LOG_PROMPT = "let's imagine how jarvis would be created with today's technology no fiction"
-EXACT_TONY_PROMPT = "let's imagine how tony stark would have created Jarvis with todays technology, no fiction"
-EXACT_CREATE_PROMPT = "how can i create an ai just like jarvis but with todays technology"
+EXACT_LOG_PROMPT = "let's imagine how assistant would be created with today's technology no fiction"
+EXACT_TONY_PROMPT = "let's imagine how fictional inventor would have created assistant with todays technology, no fiction"
+EXACT_CREATE_PROMPT = "how can i create an ai just like assistant but with todays technology"
 
 
 @dataclass
@@ -609,7 +609,7 @@ def test_action_cue_detector_ignores_conceptual_build_prompt():
 
     assert (
         alice._has_explicit_action_cue(
-            "how can i create an ai like jarvis with todays technology and no fiction"
+            "how can i create an ai like assistant with todays technology and no fiction"
         )
         is False
     )
@@ -619,7 +619,7 @@ def test_execution_mode_keeps_conceptual_create_prompt_in_conversational_mode():
     alice = ALICE.__new__(ALICE)
 
     mode, reason = alice._select_execution_mode(
-        user_input="how can i create an ai like jarvis with today's technology and no fiction",
+        user_input="how can i create an ai like assistant with today's technology and no fiction",
         intent="conversation:help",
         intent_confidence=0.71,
         has_active_goal=False,

--- a/tests/test_foundation_layers.py
+++ b/tests/test_foundation_layers.py
@@ -1,0 +1,20 @@
+from ai.core.foundation_layers import FoundationLayers
+
+
+def test_staged_inference_skips_deep_for_high_confidence_shallow_route():
+    layers = FoundationLayers(budget_ms=120.0)
+    budget = layers.new_budget()
+
+    assert layers.should_run_deep_stage(budget, shallow_confidence=0.97) is False
+
+
+def test_clarification_policy_flags_low_margin_cases():
+    layers = FoundationLayers()
+
+    state = layers.clarification_policy(
+        plugin_scores={"notes": 1.0, "email": 0.9},
+        confidence=0.9,
+    )
+
+    assert state["needs_clarification"] is True
+    assert state["top_margin"] < 0.35

--- a/tests/test_learning_engine_optimizations.py
+++ b/tests/test_learning_engine_optimizations.py
@@ -1,0 +1,112 @@
+from ai.learning.learning_engine import LearningEngine, TrainingExample
+
+
+class _FakeVector:
+    def __init__(self, values):
+        self.values = list(values)
+
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return _FakeVector(self.values[item])
+        if isinstance(item, _FakeVector):
+            return _FakeVector([self.values[i] for i in item.values])
+        if isinstance(item, list):
+            return _FakeVector([self.values[i] for i in item])
+        return self.values[item]
+
+    def __iter__(self):
+        return iter(self.values)
+
+
+class _FakeMatrix:
+    def __init__(self, rows):
+        self.rows = [_FakeVector(r) for r in rows]
+
+    def __getitem__(self, idx):
+        return self.rows[idx]
+
+
+class _FakeNP:
+    @staticmethod
+    def argpartition(values, kth):
+        base = values.values if isinstance(values, _FakeVector) else values
+        indexed = list(enumerate(base))
+        indexed.sort(key=lambda item: item[1])
+        return _FakeVector([idx for idx, _ in indexed])
+
+    @staticmethod
+    def argsort(values):
+        base = values.values if isinstance(values, _FakeVector) else values
+        return [idx for idx, _ in sorted(enumerate(base), key=lambda item: item[1])]
+
+
+class _StubVectorizer:
+    def __init__(self):
+        self.transform_calls = 0
+        self.fit_calls = 0
+
+    def fit_transform(self, texts):
+        self.fit_calls += 1
+        return _FakeMatrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+    def transform(self, texts):
+        self.transform_calls += 1
+        return _FakeMatrix([[1.0, 0.0, 0.0]])
+
+
+def test_similarity_lookup_uses_query_cache(monkeypatch, tmp_path):
+    engine = LearningEngine(data_dir=str(tmp_path / "training"))
+    stub_vectorizer = _StubVectorizer()
+
+    engine.examples = [
+        TrainingExample("alpha", "r1"),
+        TrainingExample("beta", "r2"),
+        TrainingExample("gamma", "r3"),
+    ]
+    engine.vectorizer = stub_vectorizer
+    engine._needs_refit = True
+
+    monkeypatch.setattr("ai.learning.learning_engine._ml_available", lambda: True)
+    monkeypatch.setattr("ai.learning.learning_engine.np", _FakeNP())
+    monkeypatch.setattr(
+        "ai.learning.learning_engine.cosine_similarity",
+        lambda _query, _matrix: _FakeMatrix([[0.9, 0.1, 0.2]]),
+    )
+
+    first = engine.get_similar_examples("alpha", top_k=2)
+    second = engine.get_similar_examples("alpha", top_k=2)
+
+    assert [ex.user_input for ex in first] == ["alpha"]
+    assert [ex.user_input for ex in second] == ["alpha"]
+    assert stub_vectorizer.transform_calls == 1
+
+
+def test_similarity_cache_invalidates_after_collect(monkeypatch, tmp_path):
+    engine = LearningEngine(data_dir=str(tmp_path / "training"))
+    stub_vectorizer = _StubVectorizer()
+
+    engine.examples = [
+        TrainingExample("alpha", "r1"),
+        TrainingExample("beta", "r2"),
+        TrainingExample("gamma", "r3"),
+    ]
+    engine.vectorizer = stub_vectorizer
+    engine._needs_refit = True
+
+    monkeypatch.setattr("ai.learning.learning_engine._ml_available", lambda: True)
+    monkeypatch.setattr("ai.learning.learning_engine.np", _FakeNP())
+    monkeypatch.setattr(
+        "ai.learning.learning_engine.cosine_similarity",
+        lambda _query, _matrix: _FakeMatrix([[0.9, 0.1, 0.2]]),
+    )
+
+    engine.get_similar_examples("alpha", top_k=2)
+    assert stub_vectorizer.transform_calls == 1
+
+    engine.collect_interaction("delta", "r4")
+    engine.vectorizer = stub_vectorizer
+    engine.get_similar_examples("alpha", top_k=2)
+    assert stub_vectorizer.transform_calls == 2

--- a/tests/test_nlp_processor_optimizations.py
+++ b/tests/test_nlp_processor_optimizations.py
@@ -1,0 +1,74 @@
+import pytest
+
+from ai.core.nlp_processor import NLPProcessor, ParsedCommand, RichToken
+
+
+def _token(word: str) -> RichToken:
+    return RichToken(
+        text=word,
+        normalized=word,
+        kind="word",
+        role="unknown",
+        start_pos=0,
+        end_pos=len(word),
+        flags={},
+    )
+
+
+def test_plugin_score_counts_repeated_domain_terms():
+    nlp = NLPProcessor()
+    tokens = [_token("note"), _token("note"), _token("list")]
+
+    scores = nlp._compute_plugin_scores(tokens, ParsedCommand())
+
+    assert scores["notes"] == pytest.approx(3.6)
+
+
+def test_weather_score_remains_dominant_with_forecast_signals():
+    nlp = NLPProcessor()
+    tokens = [
+        _token("weather"),
+        _token("forecast"),
+        _token("rain"),
+        _token("will"),
+        _token("rain"),
+    ]
+    parsed = ParsedCommand(action="forecast", object_type="weather")
+
+    scores = nlp._compute_plugin_scores(tokens, parsed)
+
+    assert scores["weather"] > 9.0
+    assert scores["weather"] > scores["notes"]
+
+
+def test_wake_word_prefix_is_removed_before_tokenization():
+    nlp = NLPProcessor()
+
+    debug = nlp.debug_tokenizer("Hey assistant, what is the weather tomorrow?")
+
+    assert not debug["normalized_text"].lower().startswith("assistant")
+    assert debug["parsed_command"]["object_type"] == "weather"
+
+
+def test_foundation_layer_metadata_is_attached_to_modifiers():
+    nlp = NLPProcessor()
+
+    result = nlp.process("create a note called sprint retrospective")
+    modifiers = result.parsed_command.get("modifiers", {})
+
+    assert "plan_memory" in modifiers
+    assert "evaluation_harness" in modifiers
+    assert "latency_budget" in modifiers
+    assert "clarification_policy" in modifiers
+
+
+def test_authorization_policy_blocks_high_risk_delete_language():
+    nlp = NLPProcessor()
+
+    result = nlp.process("delete all notes right now")
+    modifiers = result.parsed_command.get("modifiers", {})
+    auth = modifiers.get("authorization", {})
+
+    assert result.intent == "conversation:clarification_needed"
+    assert auth.get("requires_confirmation") is True
+    assert modifiers.get("tool_execution_disabled") is True

--- a/tests/test_phase_stack_implementations.py
+++ b/tests/test_phase_stack_implementations.py
@@ -1,0 +1,85 @@
+from ai.core.foundation_layers import FoundationLayers
+from ai.core.live_state_service import LiveStateService
+from ai.core.unified_action_engine import ActionRequest, UnifiedActionEngine
+from ai.runtime.user_state_model import UserStateModel
+from tools.auditing.core_benchmark_gate import build_kpi_snapshot
+
+
+class _WorldStateStub:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def get_environment_state(self, key: str):
+        if key == "weather":
+            return self._payload
+        return {}
+
+
+def test_foundation_layer_threshold_tuning():
+    layers = FoundationLayers()
+    before = layers.clarification_policy(plugin_scores={"notes": 1.0}, confidence=0.5)
+    tuned = layers.tune_from_outcome(false_clarification=True)
+    after = layers.clarification_policy(plugin_scores={"notes": 1.0}, confidence=0.5)
+
+    assert tuned["confidence"] < before["thresholds"]["confidence"]
+    assert after["thresholds"]["confidence"] == tuned["confidence"]
+
+
+def test_live_state_reports_staleness_metadata():
+    service = LiveStateService()
+    stub = _WorldStateStub(
+        {
+            "captured_at": 1.0,
+            "data": {"temp_c": 22},
+        }
+    )
+
+    snapshot = service.freshest_weather_snapshot(world_state_memory=stub, max_age_seconds=10)
+    assert snapshot is not None
+    assert "is_stale" in snapshot
+    assert snapshot["is_stale"] is True
+
+
+def test_unified_action_engine_recovery_recommendation():
+    engine = UnifiedActionEngine()
+    request = ActionRequest(
+        goal="delete note",
+        plugin="notes",
+        action="delete",
+        params={},
+        source_intent="notes:delete",
+        confidence=0.6,
+        retry_budget=0,
+    )
+    rec = engine._recommend_recovery_plan(
+        request=request, result_dict={"success": False}, attempt_idx=0
+    )
+    assert rec["next_step"] == "request_target_clarification"
+
+
+def test_user_state_preferences_update():
+    model = UserStateModel()
+    state = model.update_preferences(
+        user_id="u1",
+        response_brevity="concise",
+        confirmation_style="minimal",
+        risk_tolerance="low",
+    )
+    assert state.preferences["response_brevity"] == "concise"
+    assert state.preferences["confirmation_style"] == "minimal"
+    assert state.preferences["risk_tolerance"] == "low"
+
+
+def test_benchmark_kpi_snapshot_builder():
+    snapshot = build_kpi_snapshot(
+        {
+            "generated_at": "2026-04-06T00:00:00",
+            "objective_score": 0.8,
+            "intent_accuracy": 0.82,
+            "useful_response_rate": 0.78,
+            "latency_ms": {"p95": 130.0},
+            "per_domain": {"notes": {"pass_rate": 0.9}},
+        }
+    )
+    assert snapshot["objective_score"] == 0.8
+    assert snapshot["latency_p95_ms"] == 130.0

--- a/tools/auditing/core_benchmark_gate.py
+++ b/tools/auditing/core_benchmark_gate.py
@@ -298,6 +298,26 @@ def score_benchmark(benchmark_path: Path) -> Dict[str, Any]:
     return scorecard
 
 
+def build_kpi_snapshot(scorecard: Dict[str, Any]) -> Dict[str, Any]:
+    """P2 benchmark KPI bundle for dashboards/automation."""
+    latency = scorecard.get("latency_ms") or {}
+    per_domain = scorecard.get("per_domain") or {}
+    clarification_rate = 1.0 - float(scorecard.get("useful_response_rate", 0.0))
+    critical = {
+        domain: (per_domain.get(domain) or {}).get("pass_rate", 0.0)
+        for domain in CRITICAL_DOMAINS
+    }
+    return {
+        "generated_at": scorecard.get("generated_at"),
+        "objective_score": float(scorecard.get("objective_score", 0.0)),
+        "intent_accuracy": float(scorecard.get("intent_accuracy", 0.0)),
+        "useful_response_rate": float(scorecard.get("useful_response_rate", 0.0)),
+        "clarification_rate_proxy": max(0.0, min(1.0, clarification_rate)),
+        "latency_p95_ms": float(latency.get("p95", 0.0)),
+        "critical_domain_pass_rates": critical,
+    }
+
+
 def _load_scorecard(path: Path) -> Dict[str, Any]:
     if not path.exists():
         raise ValueError(f"Scorecard file not found: {path}")


### PR DESCRIPTION
### Motivation
- Add a small, composable foundation layer to centralize latency budgeting, clarification policy, grounding, and authorization for more robust routing and staged inference.
- Improve tokenizer/plugin scoring robustness and wake-word handling to reduce false routing and better surface domain signals.
- Provide freshness metadata for live-state snapshots and deterministic next-step recovery guidance for failed actions to improve reliability.
- Optimize learned-example similarity lookup with caching and invalidation and add a lightweight user preferences model and roadmap for next steps.

### Description
- Add `ai/core/foundation_layers.py` implementing `FoundationLayers`, `TurnBudget`, `PlanState`, plus clarification, authorization, grounding, staged-inference gating, threshold tuning, and recording metrics, and expose `new_budget()`/`should_run_deep_stage()` APIs.
- Integrate `FoundationLayers` into `ai/core/nlp_processor.py` to: normalize input, remove wake-word prefixes, attach plan/clarification/authorization/evaluation metadata to `parsed_command.modifiers`, run staged semantic inference controlled by `TurnBudget`, and refactor tokenizer and plugin scoring (token regex, term sets, `Counter` usage).
- Extend `ai/core/live_state_service.py` to include per-domain TTLs, compute `age_seconds`, and return `is_stale`/`ttl_seconds` in weather and forecast payloads.
- Add a deterministic recovery recommender `_recommend_recovery_plan` in `ai/core/unified_action_engine.py` and attach recovery recommendations into action `state_updates` and `recovery_path` where appropriate.
- Optimize `ai/learning/learning_engine.py` by adding a `_similarity_cache` with invalidation on new examples and using `np.argpartition` pattern for top-k selection; guard `get_similar_examples` for `top_k <= 0` and clear cache after refit/collect.
- Add `ai/runtime/user_state_model.py` preferences support and an `update_preferences` API to persist user response style and risk tolerance.
- Replace specific fictional names in prompts/heuristics across `ai/core/*` and `app/main.py` (`jarvis`/`tony stark` → `assistant`/`fictional inventor`) to neutralize examples used by concept-detection rules.
- Add new tests and utilities: `tests/test_foundation_layers.py`, `tests/test_learning_engine_optimizations.py`, `tests/test_nlp_processor_optimizations.py`, `tests/test_phase_stack_implementations.py`, update integration tests to match prompt changes, and add `ai/roadmap/assistant_foundation_next_steps.md` and `tools/auditing/core_benchmark_gate.py` helper `build_kpi_snapshot`.

### Testing
- Ran unit tests covering `FoundationLayers` behavior (`test_staged_inference_skips_deep_for_high_confidence_shallow_route`, `test_clarification_policy_flags_low_margin_cases`) which passed.
- Ran learning engine tests for similarity caching and invalidation (`test_similarity_lookup_uses_query_cache`, `test_similarity_cache_invalidates_after_collect`) which passed.
- Executed NLP processor tests for tokenizer, wake-word stripping, plugin scoring, and attached foundation metadata (`test_plugin_score_counts_repeated_domain_terms`, `test_wake_word_prefix_is_removed_before_tokenization`, `test_foundation_layer_metadata_is_attached_to_modifiers`, `test_authorization_policy_blocks_high_risk_delete_language`) which passed.
- Ran phase-stack and integration tests that exercise live-state staleness, recovery recommendation, user preference updates, and updated executive/semantic integration tests, and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f0f580b88324af8b6bafba7a94a6)